### PR TITLE
Persist dark mode preference to localStorage

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -20,6 +20,11 @@ export default function LoginPage() {
 
   // Load saved settings on mount
   useEffect(() => {
+    const savedDark = localStorage.getItem("dark-mode")
+    if (savedDark !== null) {
+      document.documentElement.classList.toggle("dark", savedDark === "true")
+    }
+
     const savedIp = localStorage.getItem("router_ip")
     if (savedIp) {
       setRouterIp(savedIp)

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -37,10 +37,13 @@ export function Sidebar({ collapsed = false, onCollapsedChange }: SidebarProps) 
   const [isCollapsed, setIsCollapsed] = useState(collapsed)
 
   useEffect(() => {
-    const isDarkMode = document.documentElement.classList.contains("dark")
+    const savedDark = localStorage.getItem("dark-mode")
+    const isDarkMode = savedDark !== null
+      ? savedDark === "true"
+      : document.documentElement.classList.contains("dark")
     setIsDark(isDarkMode)
+    document.documentElement.classList.toggle("dark", isDarkMode)
 
-    // Load collapsed state from localStorage
     const savedCollapsed = localStorage.getItem("sidebar-collapsed")
     if (savedCollapsed !== null) {
       const newCollapsed = savedCollapsed === "true"
@@ -50,8 +53,10 @@ export function Sidebar({ collapsed = false, onCollapsedChange }: SidebarProps) 
   }, [onCollapsedChange])
 
   const toggleDarkMode = () => {
-    document.documentElement.classList.toggle("dark")
-    setIsDark(!isDark)
+    const newDark = !isDark
+    document.documentElement.classList.toggle("dark", newDark)
+    setIsDark(newDark)
+    localStorage.setItem("dark-mode", String(newDark))
   }
 
   const toggleCollapsed = () => {


### PR DESCRIPTION
  - useEffect: reads dark-mode from localStorage on mount; if found, applies it to the DOM and state. Falls back to the current DOM class if no saved preference exists.
  - toggleDarkMode: saves the new value to localStorage on every toggle, same pattern as sidebar-collapsed.